### PR TITLE
feature: implementation of profile creation when registering a user

### DIFF
--- a/src/main/java/br/com/combathub/combat_hub/controller/UserController.java
+++ b/src/main/java/br/com/combathub/combat_hub/controller/UserController.java
@@ -37,6 +37,9 @@ public class UserController {
     @Autowired
     private TokenService tokenService;
 
+    @Autowired
+    private ProfileService profileService;
+
     @PostMapping("/login")
     @PreAuthorize("@userService.isEmailConfirmed(#dto.login())")
     public ResponseEntity<JWTTokenDTO> login(@Valid @RequestBody AuthenticationDTO dto) throws AuthenticationException {
@@ -54,6 +57,7 @@ public class UserController {
         var user = this.userService.registerUser(
                 new UserEntity(userRegistrationDTO.login(), encodedPassword, userRegistrationDTO.role())
         );
+        this.profileService.createProfile(userRegistrationDTO, user);
         this.verificationCodeService.registerCode(user);
     }
 

--- a/src/main/java/br/com/combathub/combat_hub/controller/UserController.java
+++ b/src/main/java/br/com/combathub/combat_hub/controller/UserController.java
@@ -1,9 +1,7 @@
 package br.com.combathub.combat_hub.controller;
 
-import br.com.combathub.combat_hub.domain.user.AuthenticationDTO;
-import br.com.combathub.combat_hub.domain.user.UserDTO;
-import br.com.combathub.combat_hub.domain.user.UserEntity;
-import br.com.combathub.combat_hub.domain.user.UserService;
+import br.com.combathub.combat_hub.domain.profile.*;
+import br.com.combathub.combat_hub.domain.user.*;
 import br.com.combathub.combat_hub.domain.verification_code.VerificationCodeService;
 import br.com.combathub.combat_hub.infra.security.JWTTokenDTO;
 import br.com.combathub.combat_hub.infra.security.TokenService;
@@ -50,11 +48,11 @@ public class UserController {
 
     @PostMapping("/register")
     @Transactional
-    @PreAuthorize("@userService.isEmailRegistered(#dto.login())")
-    public void register(@Valid @RequestBody UserDTO dto) {
-        var encodedPassword = encoder.encode(dto.password());
+    @PreAuthorize("@userService.isEmailRegistered(#userRegistrationDTO.login())")
+    public void register(@Valid @RequestBody UserRegistrationDTO userRegistrationDTO) {
+        var encodedPassword = encoder.encode(userRegistrationDTO.password());
         var user = this.userService.registerUser(
-                new UserEntity(dto.login(), encodedPassword, dto.role())
+                new UserEntity(userRegistrationDTO.login(), encodedPassword, userRegistrationDTO.role())
         );
         this.verificationCodeService.registerCode(user);
     }

--- a/src/main/java/br/com/combathub/combat_hub/domain/MartialArtsModalities.java
+++ b/src/main/java/br/com/combathub/combat_hub/domain/MartialArtsModalities.java
@@ -1,0 +1,8 @@
+package br.com.combathub.combat_hub.domain;
+
+public enum MartialArtsModalities {
+    BRAZILIANJIUJITSU,
+    JUDO,
+    KARATE,
+    MMA
+}

--- a/src/main/java/br/com/combathub/combat_hub/domain/profile/AthleteEntity.java
+++ b/src/main/java/br/com/combathub/combat_hub/domain/profile/AthleteEntity.java
@@ -1,0 +1,27 @@
+package br.com.combathub.combat_hub.domain.profile;
+
+import br.com.combathub.combat_hub.domain.MartialArtsModalities;
+import br.com.combathub.combat_hub.domain.user.UserRegistrationDTO;
+import br.com.combathub.combat_hub.domain.user.UserEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Table(name = "athletes")
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class AthleteEntity extends Profile {
+
+    private MartialArtsModalities modality;
+
+    public AthleteEntity(UserRegistrationDTO dto, UserEntity user) {
+        super(dto, user);
+        this.modality = dto.modality();
+    }
+
+}

--- a/src/main/java/br/com/combathub/combat_hub/domain/profile/AthleteRepository.java
+++ b/src/main/java/br/com/combathub/combat_hub/domain/profile/AthleteRepository.java
@@ -1,0 +1,6 @@
+package br.com.combathub.combat_hub.domain.profile;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AthleteRepository extends JpaRepository<AthleteEntity, Long> {
+}

--- a/src/main/java/br/com/combathub/combat_hub/domain/profile/GymEntity.java
+++ b/src/main/java/br/com/combathub/combat_hub/domain/profile/GymEntity.java
@@ -1,0 +1,23 @@
+package br.com.combathub.combat_hub.domain.profile;
+
+import br.com.combathub.combat_hub.domain.user.UserRegistrationDTO;
+import br.com.combathub.combat_hub.domain.user.UserEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Table(name = "gyms")
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class GymEntity extends Profile {
+
+    public GymEntity(UserRegistrationDTO dto, UserEntity entity) {
+        super(dto, entity);
+    }
+
+}

--- a/src/main/java/br/com/combathub/combat_hub/domain/profile/GymRepository.java
+++ b/src/main/java/br/com/combathub/combat_hub/domain/profile/GymRepository.java
@@ -1,0 +1,6 @@
+package br.com.combathub.combat_hub.domain.profile;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GymRepository extends JpaRepository<GymEntity, Long> {
+}

--- a/src/main/java/br/com/combathub/combat_hub/domain/profile/OrganizationEntity.java
+++ b/src/main/java/br/com/combathub/combat_hub/domain/profile/OrganizationEntity.java
@@ -1,0 +1,23 @@
+package br.com.combathub.combat_hub.domain.profile;
+
+import br.com.combathub.combat_hub.domain.user.UserRegistrationDTO;
+import br.com.combathub.combat_hub.domain.user.UserEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Table(name = "organizations")
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class OrganizationEntity extends Profile {
+
+    public OrganizationEntity(UserRegistrationDTO dto, UserEntity entity) {
+        super(dto, entity);
+    }
+
+}

--- a/src/main/java/br/com/combathub/combat_hub/domain/profile/OrganizationRepository.java
+++ b/src/main/java/br/com/combathub/combat_hub/domain/profile/OrganizationRepository.java
@@ -1,0 +1,6 @@
+package br.com.combathub.combat_hub.domain.profile;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrganizationRepository extends JpaRepository<OrganizationEntity, Long> {
+}

--- a/src/main/java/br/com/combathub/combat_hub/domain/profile/Profile.java
+++ b/src/main/java/br/com/combathub/combat_hub/domain/profile/Profile.java
@@ -1,0 +1,43 @@
+package br.com.combathub.combat_hub.domain.profile;
+
+import br.com.combathub.combat_hub.domain.user.UserRegistrationDTO;
+import br.com.combathub.combat_hub.domain.user.UserEntity;
+import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@NoArgsConstructor
+@Getter
+@ToString
+@EqualsAndHashCode(of = "id")
+@MappedSuperclass
+@SuperBuilder
+public abstract class Profile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @OneToOne
+    @JoinColumn(name = "user")
+    private UserEntity user;
+
+    private String name;
+
+    private String avatar;
+
+    private LocalDateTime registeredAt;
+
+    public Profile(UserRegistrationDTO dto, UserEntity entity) {
+        this.user = entity;
+        this.name = dto.name();
+        this.avatar = dto.avatar();
+        this.registeredAt = LocalDateTime.now(ZoneId.of("America/Sao_Paulo"));
+    }
+}

--- a/src/main/java/br/com/combathub/combat_hub/domain/profile/ProfileService.java
+++ b/src/main/java/br/com/combathub/combat_hub/domain/profile/ProfileService.java
@@ -1,0 +1,31 @@
+package br.com.combathub.combat_hub.domain.profile;
+
+import br.com.combathub.combat_hub.domain.user.UserRegistrationDTO;
+import br.com.combathub.combat_hub.domain.user.UserEntity;
+import br.com.combathub.combat_hub.domain.user.UserRole;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProfileService {
+
+    @Autowired
+    private AthleteRepository athleteRepository;
+
+    @Autowired
+    private GymRepository gymRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    public void createProfile(UserRegistrationDTO dto, UserEntity user) {
+        if(dto.role().equals(UserRole.ATHLETE)) {
+            athleteRepository.save(new AthleteEntity(dto, user));
+        } else if (dto.role().equals(UserRole.GYM)) {
+            gymRepository.save(new GymEntity(dto, user));
+        } else {
+            organizationRepository.save(new OrganizationEntity(dto, user));
+        };
+    }
+
+}

--- a/src/main/java/br/com/combathub/combat_hub/domain/user/UserRegistrationDTO.java
+++ b/src/main/java/br/com/combathub/combat_hub/domain/user/UserRegistrationDTO.java
@@ -1,12 +1,12 @@
 package br.com.combathub.combat_hub.domain.user;
 
-import jakarta.persistence.EnumType;
+import br.com.combathub.combat_hub.domain.MartialArtsModalities;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
 
-public record UserDTO(
+public record UserRegistrationDTO(
         @NotNull
         @Email
         String login,
@@ -17,6 +17,15 @@ public record UserDTO(
 
         @NotNull
         @Enumerated
-        UserRole role
+        UserRole role,
+
+        @NotNull
+        @Length(min = 3, max = 100)
+        String name,
+
+        @Enumerated
+        MartialArtsModalities modality,
+
+        String avatar
 ) {
 }

--- a/src/main/java/br/com/combathub/combat_hub/domain/user/UserRole.java
+++ b/src/main/java/br/com/combathub/combat_hub/domain/user/UserRole.java
@@ -2,5 +2,6 @@ package br.com.combathub.combat_hub.domain.user;
 
 public enum UserRole {
     ORGANIZER,
-    TEAM
+    GYM,
+    ATHLETE
 }

--- a/src/main/resources/db/migration/V2__create_table_profiles.sql
+++ b/src/main/resources/db/migration/V2__create_table_profiles.sql
@@ -1,0 +1,34 @@
+CREATE TABLE athletes (
+    id BIGINT AUTO_INCREMENT UNIQUE,
+    user BIGINT UNIQUE NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    modality VARCHAR(25) NOT NULL,
+    avatar VARCHAR(255),
+    registered_at DATETIME,
+
+    PRIMARY KEY (id),
+    FOREIGN KEY (user) REFERENCES users(id)
+);
+
+CREATE TABLE organizations (
+    id BIGINT AUTO_INCREMENT UNIQUE,
+    user BIGINT UNIQUE NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    avatar VARCHAR(255),
+    registered_at DATETIME,
+
+    PRIMARY KEY (id),
+    FOREIGN KEY (user) REFERENCES users(id)
+);
+
+CREATE TABLE gyms (
+    id BIGINT AUTO_INCREMENT UNIQUE,
+    user BIGINT UNIQUE NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    type VARCHAR(25) NOT NULL,
+    avatar VARCHAR(255),
+    registered_at DATETIME,
+
+    PRIMARY KEY (id),
+    FOREIGN KEY (user) REFERENCES users(id)
+);


### PR DESCRIPTION
### Changes made:
- Separation of authentication data from public profile data;
- Creation of `ProfileService` and `ProfileController`;
- Creation of a base abstract class to profile with common atributes used by subclasses and creation of the subclasses `AthleteEntity`, `GymEntity` and `OrganizationEntity` to map specifics types of profiles;
- Creation of the migration to the tables creation in the database;
- Update of the `UserRole`s enum;
- Creation of `MartialArtsModalitys` enum;
- Renomination and update to the `UserRegistrationDTO` to include the profile data;

### Why separate the authentication data from the profile data?
In the future we want to implement the possibility of different users have access to the gyms and organization accounts and different levels of authorities, like a  coach from a gym to manage their clients or staff from organizations to keep track of subscriptions in a event. And I think that making this  decision now can make it easier to make these changes wen the time come.

### Why have different types of profiles?
This is a long term decision too. For the alpha version we don't need much specific data from each type, but in the futures versions we will.

@Redon913 @Charlesnorris509 please make a review to the PR and let me know if you disagree with any decision made in here.